### PR TITLE
refactor: delegate recipe search to module

### DIFF
--- a/deploy/public/app.js
+++ b/deploy/public/app.js
@@ -438,21 +438,6 @@ class GroceryApp {
         if (this.realRecipesManager?.initializeDOMElements) {
             this.realRecipesManager.initializeDOMElements();
         }
-        this.recipeSearchInput = this.realRecipesManager?.getRecipeSearchInput?.();
-        this.clearRecipeSearchBtn = this.realRecipesManager?.getClearRecipeSearchBtn?.();
-        this.addRecipeBtn = this.realRecipesManager?.getAddRecipeBtn?.();
-        this.importRecipeBtn = this.realRecipesManager?.getImportRecipeBtn?.();
-        this.recipeJsonFileInput = this.realRecipesManager?.getRecipeJsonFileInput?.();
-        this.recipesList = this.realRecipesManager?.getRecipesList?.();
-        this.recipeCount = this.realRecipesManager?.getRecipeCount?.();
-        this.filteredRecipeCount = this.realRecipesManager?.getFilteredRecipeCount?.();
-
-        this.cuisineFilter = this.realRecipesManager?.getCuisineFilter?.();
-        this.mainIngredientFilter = this.realRecipesManager?.getMainIngredientFilter?.();
-        this.seasonFilter = this.realRecipesManager?.getSeasonFilter?.();
-        this.stockFilter = this.realRecipesManager?.getStockFilter?.();
-        this.clearFiltersBtn = this.realRecipesManager?.getClearFiltersBtn?.();
-        this.aiSuggestBtn = this.realRecipesManager?.getAiSuggestBtn?.();
 
         // Meal planning elements
         this.prevWeekBtn = document.getElementById('prevWeekBtn');
@@ -1248,20 +1233,6 @@ class GroceryApp {
     clearProductSearch() {
         return this.productsManager.clearProductSearch();
     }
-
-    searchRecipes() {
-        const searchTerm = this.recipeSearchInput?.value?.trim() || '';
-        // console.log('🔍 Recipe search triggered, search term:', searchTerm);
-        this.renderRecipes(searchTerm);
-    }
-
-    clearRecipeSearch() {
-        if (this.recipeSearchInput) {
-            this.recipeSearchInput.value = '';
-            this.searchRecipes(); // Re-render to show all recipes
-        }
-    }
-
 
     // Add recipe ingredients to shopping list
     addRecipeIngredientsToShopping(recipeId, servingMultiplier = 1) {
@@ -3575,8 +3546,8 @@ class GroceryApp {
         console.log('✅ Products list rendered with', productsToRender.length, 'of', filteredProducts.length, 'products');
     }
 
-    renderRecipes(searchTerm = '') {
-        this.realRecipesManager.renderRecipes(searchTerm);
+    renderRecipes(searchTerm = '', filters = null) {
+        this.realRecipesManager.renderRecipes(searchTerm, filters);
     }
 
     generateAIRecipes() {

--- a/deploy/public/recipes-real.js
+++ b/deploy/public/recipes-real.js
@@ -1202,7 +1202,7 @@ class RealRecipesManager {
     /**
      * Search recipes by multiple criteria
      */
-    searchRecipes(query, filters = {}) {
+    searchRecipesData(query, filters = {}) {
         if (!query && Object.keys(filters).length === 0) {
             return this.recipes;
         }
@@ -1773,14 +1773,14 @@ class RealRecipesManager {
     /**
      * Render recipes tab (main entry point)
      */
-    renderRecipes(searchTerm = '') {
+    renderRecipes(searchTerm = '', filters = null) {
         // Re-initialize DOM elements if needed
         this.initializeDOMElements();
-        
+
         // Populate filter dropdowns with current recipe data
         this.populateFilterDropdowns();
-        
-        this.renderRecipesList(searchTerm);
+
+        this.renderRecipesList(searchTerm, filters);
     }
 
     /**
@@ -1845,6 +1845,18 @@ class RealRecipesManager {
         }
     }
 
+    searchRecipes() {
+        const searchTerm = this.recipeSearchInput?.value?.trim() || '';
+        this.renderRecipes(searchTerm);
+    }
+
+    clearRecipeSearch() {
+        if (this.recipeSearchInput) {
+            this.recipeSearchInput.value = '';
+        }
+        this.renderRecipes('');
+    }
+
     /**
      * Attach event listeners for recipe UI elements
      */
@@ -1852,19 +1864,11 @@ class RealRecipesManager {
         this.initializeDOMElements();
 
         if (this.recipeSearchInput) {
-            this.recipeSearchInput.addEventListener('input', () => {
-                const term = this.recipeSearchInput.value.trim();
-                this.renderRecipes(term);
-            });
+            this.recipeSearchInput.addEventListener('input', () => this.searchRecipes());
         }
 
         if (this.clearRecipeSearchBtn) {
-            this.clearRecipeSearchBtn.addEventListener('click', () => {
-                if (this.recipeSearchInput) {
-                    this.recipeSearchInput.value = '';
-                }
-                this.renderRecipes('');
-            });
+            this.clearRecipeSearchBtn.addEventListener('click', () => this.clearRecipeSearch());
         }
 
         if (this.addRecipeBtn) {
@@ -2010,18 +2014,18 @@ class RealRecipesManager {
     /**
      * Render recipes list with filtering and search
      */
-    renderRecipesList(searchTerm = '') {
+    renderRecipesList(searchTerm = '', filters = null) {
         this.initializeDOMElements();
-        
+
         let recipesToShow = this.recipes;
-        
+
         // Apply search if provided
         if (searchTerm) {
-            recipesToShow = this.searchRecipes(searchTerm);
+            recipesToShow = this.searchRecipesData(searchTerm);
         }
-        
-        // Get active global filters
-        const activeFilters = this.getActiveFilters();
+
+        // Determine active global filters
+        const activeFilters = filters || this.getActiveFilters();
         const hasFilters = Object.keys(activeFilters).length > 0;
         
         // Update clear filters button visibility
@@ -2195,7 +2199,8 @@ class RealRecipesManager {
      */
     applyRecipeFilters() {
         const searchTerm = this.recipeSearchInput ? this.recipeSearchInput.value.toLowerCase().trim() : '';
-        this.renderRecipesList(searchTerm);
+        const filters = this.getActiveFilters();
+        this.renderRecipes(searchTerm, filters);
     }
 
     /**
@@ -2218,7 +2223,7 @@ class RealRecipesManager {
         
         // Re-render with current search term but no filters
         const searchTerm = this.recipeSearchInput ? this.recipeSearchInput.value.toLowerCase().trim() : '';
-        this.renderRecipesList(searchTerm);
+        this.renderRecipes(searchTerm, {});
     }
 
     /**


### PR DESCRIPTION
## Summary
- move recipe search & clear helpers into RealRecipesManager
- allow recipe rendering to accept search and filter params
- drop redundant recipe helpers from app.js

## Testing
- `node --check deploy/public/app.js`
- `node --check deploy/public/recipes-real.js`


------
https://chatgpt.com/codex/tasks/task_b_68b2e41b7868832685783f50459f503a