### PR TITLE
refactor: centralize pantry UI event handling

### DIFF
--- a/deploy/public/app.js
+++ b/deploy/public/app.js
@@ -400,13 +400,6 @@ class GroceryApp {
         this.groceryList = document.getElementById('groceryList');
         this.itemCount = document.getElementById('itemCount');
 
-        // Pantry tab elements
-        this.standardItemInput = document.getElementById('standardItemInput');
-        this.standardCategorySelect = document.getElementById('standardCategorySelect');
-        this.addStandardBtn = document.getElementById('addStandardBtn');
-        this.standardList = document.getElementById('standardList');
-        this.addAllUnstockedBtn = document.getElementById('addAllUnstocked');
-
         // Category tab elements
         this.categoryInput = document.getElementById('categoryInput');
         this.categoryEmojiInput = document.getElementById('categoryEmojiInput');
@@ -652,45 +645,6 @@ class GroceryApp {
                 }
             }
         });
-
-        // Pantry events - use real pantry manager directly
-        this.addStandardBtn.addEventListener('click', () => {
-            if (window.realPantryManager) {
-                const itemName = this.standardItemInput.value.trim();
-                const category = this.standardCategorySelect.value;
-                
-                if (!itemName) {
-                    this.standardItemInput.focus();
-                    return;
-                }
-                
-                const result = window.realPantryManager.addItem(itemName, category);
-                if (result) {
-                    this.standardItemInput.value = '';
-                    this.standardItemInput.focus();
-                    window.realPantryManager.refreshDisplay();
-                }
-            }
-        });
-        this.standardItemInput.addEventListener('keypress', (e) => {
-            if (e.key === 'Enter' && window.realPantryManager) {
-                const itemName = this.standardItemInput.value.trim();
-                const category = this.standardCategorySelect.value;
-                
-                if (!itemName) {
-                    this.standardItemInput.focus();
-                    return;
-                }
-                
-                const result = window.realPantryManager.addItem(itemName, category);
-                if (result) {
-                    this.standardItemInput.value = '';
-                    this.standardItemInput.focus();
-                    window.realPantryManager.refreshDisplay();
-                }
-            }
-        });
-        this.addAllUnstockedBtn.addEventListener('click', () => window.realShoppingListManager.addAllUnstockedToShopping());
 
         // Category events
         this.addCategoryBtn.addEventListener('click', () => this.addCategory());

--- a/deploy/public/pantry-manager-real.js
+++ b/deploy/public/pantry-manager-real.js
@@ -47,6 +47,9 @@ class RealPantryManager {
             console.warn('⚠️ Products manager not yet available - pantry will use filtered views when ready');
         }
         
+        // Set up UI event listeners
+        this.setupEventListeners();
+
         const pantryCount = this.getPantryProducts().length;
         // console.log(`🏠 Pantry Manager initialized - ${pantryCount} pantry items (unified v6.0.0)`);
         return this;
@@ -72,6 +75,52 @@ class RealPantryManager {
             return [];
         }
         return window.realProductsCategoriesManager.getAllProducts();
+    }
+
+    /**
+     * Set up pantry-specific UI event listeners
+     */
+    setupEventListeners() {
+        const addBtn = document.getElementById('addStandardBtn');
+        const itemInput = document.getElementById('standardItemInput');
+        const categorySelect = document.getElementById('standardCategorySelect');
+        const addAllUnstockedBtn = document.getElementById('addAllUnstocked');
+
+        if (addBtn && itemInput && categorySelect) {
+            const handleAdd = () => {
+                const itemName = itemInput.value.trim();
+                const category = categorySelect.value;
+
+                if (!itemName) {
+                    itemInput.focus();
+                    return;
+                }
+
+                const result = this.addItem(itemName, category);
+                if (result) {
+                    itemInput.value = '';
+                    itemInput.focus();
+                    this.refreshDisplay();
+                }
+            };
+
+            addBtn.addEventListener('click', handleAdd);
+            itemInput.addEventListener('keypress', (e) => {
+                if (e.key === 'Enter') {
+                    handleAdd();
+                }
+            });
+        } else {
+            console.warn('⚠️ Pantry add controls not found - event listeners not attached');
+        }
+
+        if (addAllUnstockedBtn) {
+            addAllUnstockedBtn.addEventListener('click', () => {
+                if (window.realShoppingListManager && window.realShoppingListManager.addAllUnstockedToShopping) {
+                    window.realShoppingListManager.addAllUnstockedToShopping();
+                }
+            });
+        }
     }
 
     // v6.0.0 UNIFIED: Storage methods removed - all data managed by products manager


### PR DESCRIPTION
## Summary
- move pantry item addition and bulk sync buttons into `pantry-manager-real.js`
- drop pantry-specific DOM references and events from `app.js`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68b2f67344708326a9777fca70218b74